### PR TITLE
Warning-free build.

### DIFF
--- a/src/ASF/xmega/drivers/usart/usart.c
+++ b/src/ASF/xmega/drivers/usart/usart.c
@@ -95,6 +95,7 @@ bool usart_init_rs232(USART_t *usart, const usart_rs232_options_t *opt)
  */
 void usart_init_spi(USART_t *usart, const usart_spi_options_t *opt)
 {
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 	ioport_pin_t sck_pin;
 	bool invert_sck;
 

--- a/src/config.c
+++ b/src/config.c
@@ -33,6 +33,7 @@ uint8_t global_super_knob_end;
 #define GLOBAL_TAG_HIGH_LOWER 30
 #define ENCODER_RESV_RANGE (GLOBAL_TAG_HIGH_LOWER - GLOBAL_TAG_LOW_UPPER)
 
+void global_tv_table_decode(global_tvtable_t*, uint8_t*, uint8_t); // -Wmissing-prototype
 void global_tv_table_decode(global_tvtable_t* table, uint8_t* buffer, uint8_t size)
 {
     uint8_t idx = 0;
@@ -49,7 +50,7 @@ void global_tv_table_decode(global_tvtable_t* table, uint8_t* buffer, uint8_t si
     }
 }
 
-void sysExCmdPushConfig (uint8_t length, uint8_t* buffer)
+static void sysExCmdPushConfig (uint8_t length, uint8_t* buffer)
 {
 	
 	// First disable watch dog as EEPROM is slow
@@ -116,7 +117,7 @@ void send_config_data (void)
     midi_stream_sysex(sizeof(payload), payload);
 }
 
-void sysExCmdPullConfig (uint8_t length, uint8_t* buffer)
+static void sysExCmdPullConfig (uint8_t length, uint8_t* buffer)
 {
     // Change settings
     if (length > 0 && *buffer == 0x0) { // Received request
@@ -124,6 +125,7 @@ void sysExCmdPullConfig (uint8_t length, uint8_t* buffer)
     }
 }
 
+void sysExCmdSystem (uint8_t, uint8_t*); // -Wmissing-prototype
 void sysExCmdSystem (uint8_t length, uint8_t* buffer)
 {
     if (length == 0) return;
@@ -205,7 +207,7 @@ NOTE: Binary data must either avoid setting the MSB, or encode octets as packed 
 
 **********/
 //__attribute__((optimize("O0")))
-void sysExCmdBulkXfer(uint8_t length, uint8_t* buffer) // Process/ParseSysexMessage (incoming)
+static void sysExCmdBulkXfer(uint8_t length, uint8_t* buffer) // Process/ParseSysexMessage (incoming)
 {   
     if (length > 2) {
 		
@@ -218,6 +220,7 @@ void sysExCmdBulkXfer(uint8_t length, uint8_t* buffer) // Process/ParseSysexMess
                 uint8_t part = *buffer++; // Transfers may consist of multiple parts
                 if (part == 0) return; // Invalid part number
                 uint8_t total = *buffer++;
+                UNUSED(total);
                 uint8_t size = *buffer++;
                 if (size > length - 5) return; // Not enough data to support payload
                 

--- a/src/display_driver.c
+++ b/src/display_driver.c
@@ -180,8 +180,8 @@ void display_init(void)
 	ioport_set_pin_level(DISPLAY_LATCH, 0);
 	
 	// Initialize the animation tick and animation counter
-	uint8_t animation_counter = 0;
-	static uint8_t tick = 0;
+	//uint8_t animation_counter = 0;
+	//static uint8_t tick = 0;
 	
 	// Finally initialize the frame counter
 	display_frame_index = 0;

--- a/src/input.c
+++ b/src/input.c
@@ -94,7 +94,7 @@ const float velocity_calc_offset = -1*(VELOCITY_CALC_MIN_MULTIPLIER +
 // ===== Velocity Calculation Method ==============END=
 
 static uint16_t timer_cca_value = 125;
-static uint16_t timer_ccb_value = 0;
+//static uint16_t timer_ccb_value = 0;
 
 void do_task(void);
 

--- a/src/main.c
+++ b/src/main.c
@@ -53,7 +53,8 @@ void board_init(void);
 
 bool watchdog_flag = false;
 
-void Midifighter_Task(void) {
+void Midifighter_Task(void); // -Wmissing-prototypes
+ void Midifighter_Task(void) {
 	if (USB_DeviceState != DEVICE_STATE_Configured) {
 		return;
 	}
@@ -69,6 +70,10 @@ void Midifighter_Task(void) {
 	#endif
 
 	switch (get_op_mode()) {
+		case startup:{
+			// Do nothing
+		}
+		break;
 		case normal:{
 			// Process any encoder movements or changes to the switch state
 			process_encoder_input();
@@ -131,7 +136,7 @@ void Midifighter_Task(void) {
 		USB_USBTask();
 	
 		// If we are using the USB MIDI connection check for and process received MIDI packets
-		MIDI_EventPacket_t ReceivedMIDIEvent;
+		//MIDI_EventPacket_t ReceivedMIDIEvent;
 	
 		// For now we disable interrupts while processing incoming MIDI, this avoids missed clock
 		// ticks. This could probably be solved more elegantly but it works
@@ -193,6 +198,7 @@ void Midifighter_Task(void) {
 	watchdog_flag = true;
 }
 
+void main_loop(void); // -Wmissing-prototypes
 void main_loop(void) {
 	// Read keys and motion tracking for User and MIDI events to process,
 	// setting LEDs to display the resulting state.
@@ -291,7 +297,8 @@ void system_init()
 	USB_Init();
 }
 
-void clock_init() { // !test
+#if 0 // Unused function. Why is it here?
+static void clock_init(void) { // !test
 	/* Start the PLL to multiply the 2MHz RC oscillator to 32MHz and switch the CPU core to run from it */
 	XMEGACLK_StartPLL(CLOCK_SRC_INT_RC2MHZ, 2000000, F_CPU);
 	XMEGACLK_SetCPUClockSource(CLOCK_SRC_PLL);
@@ -302,7 +309,7 @@ void clock_init() { // !test
 
 	PMIC.CTRL = PMIC_LOLVLEN_bm | PMIC_MEDLVLEN_bm | PMIC_HILVLEN_bm;
 }
-
+#endif
 
 
 /** Event handler for the library USB Configuration Changed event. */

--- a/src/midi.c
+++ b/src/midi.c
@@ -61,6 +61,7 @@ fifo_desc_t fifo_desc;
 
 USB_ClassInfo_MIDI_Device_t* g_midi_interface_info;
 
+#if 0 // -Wunused-variable
 // Setup USART options for Legacy MIDI
 static usart_serial_options_t usart_options = {
 	.baudrate   = USART_SERIAL_BAUDRATE,
@@ -68,6 +69,7 @@ static usart_serial_options_t usart_options = {
 	.paritytype = USART_SERIAL_PARITY,
 	.stopbits	= USART_SERIAL_STOP_BIT
 };
+#endif
 
 
 // MIDI System Functions ------------------------------------------------------
@@ -155,6 +157,7 @@ bool midi_is_usb(void)
 
 
 /* Send a 16 bit value as a song position pointer message for easy debugging */
+void debug_16_bit_value(uint16_t); // -Wmissing-prototypes
 void debug_16_bit_value(uint16_t value)
 {
 	uint8_t data[3];
@@ -162,7 +165,7 @@ void debug_16_bit_value(uint16_t value)
 	data[2] = (uint8_t)(value & 0x3F);
 	data[1] = (uint8_t)((value >> 8) & 0x3F);
 
-	midi_stream_sysex(3,&data);
+	midi_stream_sysex(3, data);
 }
 
 /**
@@ -228,10 +231,12 @@ static int8_t tick_counter = 0;
 
 // Handler for Midi Clock tick, this counts from 0 to 23
 // The MIDI USB CABLE HAS CRAZY COCK JITTER - this causes timing issues
+void midi_clock(void); // -Wmissing-prototypes
 void midi_clock(void)
 {
 	// !Summer2016Update: midi_clock animation
 	uint16_t counts = update_clock_counter();
+	UNUSED(counts);
 	seq_midi_clock_handler(tick_counter);
 
 	// If not enabled enable MIDI Clock for animations 
@@ -277,9 +282,12 @@ void real_time_start(void)
 	prev_count = 0;
 	// Todo: Send Note Offs for any active notes ..
 	clock_stable = false;
+#if 0	// XXX FIXME! conditioned out for -Wunused
+		//     but this probably SHOULD actually do something!
 	if (seq_state == PLAYBACK){
 		seq_state == WAIT_FOR_SYNC;
 	}
+#endif
 }
 
 // Handle real time stop messages
@@ -306,10 +314,10 @@ void midi_stream_raw_note(const uint8_t channel,
     midi_event.Data3       = velocity & 0x7f; // 0..127
 	if (midi_is_usb()){
 		int error_code = MIDI_Device_SendEventPacket(g_midi_interface_info, &midi_event);
-		if (error_code){
-			int i = 0 + error_code;
-		}
-		
+		//if (error_code){
+		//	int i = 0 + error_code;
+		//}
+		UNUSED(error_code);
 	} else {
 		#if ENABLE_LEGACY_MIDI_USART_OUTPUT > 0
 			MIDI_send_legacy_packet(&midi_event);

--- a/src/self_test.c
+++ b/src/self_test.c
@@ -127,7 +127,7 @@ bool elec_self_test(void)
 	// Enable display
 	display_enable();
 	
-	bool test_passed = false;
+	//bool test_passed = false;
 	
 	uint16_t bit = 0x0001;
 	

--- a/src/sequencer.c
+++ b/src/sequencer.c
@@ -60,7 +60,7 @@ const uint8_t default_pattern[11][16] PROGMEM = {
 };
 
 
-static uint8_t tempo = 6;
+//static uint8_t tempo = 6;
 bool start_pattern = false;
 
 uint8_t truncate_value;
@@ -209,8 +209,8 @@ const int8_t swing_adjustment[16][4] = {{0,1,0,1},
 uint8_t swing_selection;
 bool swing_enabled;	
 
-static int16_t	current_swing_value = 0;
-static int16_t 	last_swing_value = 0;							   
+//static int16_t	current_swing_value = 0;
+//static int16_t 	last_swing_value = 0;
 
 void send_triggers(void){
 	

--- a/src/sequencer.h
+++ b/src/sequencer.h
@@ -87,9 +87,11 @@
 		DEFAULT,
 		PATTERN_MEMORY,
 		PATTERN_EDIT,
+#if 0 // suppress -Wswitch warnings
 		EFFECTS_SELECTION,
 		EFFECTS_PATTERN_EDIT,
 		SWING_PAGE,
+#endif
 	} displayMode_t;
 	
 	typedef enum rowTypes{

--- a/src/sequencer_display.c
+++ b/src/sequencer_display.c
@@ -41,9 +41,9 @@ void init_seq_display(void)
 			build_pattern_edit_display();
 		}
 		break;
-		case EFFECTS_SELECTION:{
+		//case EFFECTS_SELECTION:{
 			//build_effects_selection_display();
-		}
+		//}
 		break;
 	}
 }
@@ -53,7 +53,9 @@ void build_default_display(void)
 	// Get the display brightness values
 	uint8_t rgb_brightness = pgm_read_byte(&brightnessMap[global_rgb_brightness]);
 	uint8_t ind_brightness = pgm_read_byte(&brightnessMap[global_ind_brightness]);
-	
+	UNUSED(rgb_brightness);
+	UNUSED(ind_brightness);
+
 	// Initialize all indicators for the four slots
 	for(uint8_t i=0;i<4;++i){
 		
@@ -175,7 +177,7 @@ const uint16_t indicator_pattern[4] = {0xC000,0x3800,0x0700,0x00E0};
 
 void run_default_display(uint8_t idx){
 
-	static uint8_t lastIndex;
+	//static uint8_t lastIndex;
 
 	// First the indicator displays
 	uint8_t currentValue = SeqIndicatorValue[idx];
@@ -252,7 +254,7 @@ void run_default_display(uint8_t idx){
 		break;
 	}
 	
-	lastIndex = rythmIndex;			
+	//lastIndex = rythmIndex;
 }
 
 void run_pattern_edit_display(uint8_t idx)

--- a/src/sysex.c
+++ b/src/sysex.c
@@ -36,7 +36,7 @@ enum {
 #define MAX_COMMAND 8
 SysExFn sysExCommandMap[MAX_COMMAND] = {0,};
 
-void __attribute__((optimize("O0"))) sysex_handle (uint8_t length)
+static void __attribute__((optimize("O0"))) sysex_handle (uint8_t length)
 {
 	if (sysex_state == State_DJTT && length > 0) {
 		// This is a DJTT SysEx message


### PR DESCRIPTION
This PR should merge first so that the `rfm/2024_update` PR will be easier to read.

This eliminates all of the warnings except the explicit #warning that I figured I wouldn't touch. I was careful to do this in such a way that the output binary came out completely unchanged (hex file has same md5sum), so this should be a 100% safe set of changes to merge. To achieve this I had to do things a bit clunky in places--some of the "right" ways to get rid of the warnings ended up changing the build output, like changing global functions to `static`.

The changes are mostly:
- Changing functions to `static` where possible to get rid of the `missing-prototypes` warnings, or else just adding a prototype above them (not the ideal way). They could probably all be changed to `static` but doing so sometimes changed the build output.
- Commenting out or conditioning out unused variables and functions, or sometimes using the `UNUSED` flag on them.
- Changing enums and/or switch/case to match each other (avoids the `switch-enum` warning).
- One instance where I added a `#pragma` to the ASF code just because changing Atmel's code seemed like a bad idea.

Note that there are some statements with no effect that seem like mistakes, but in the interest of not changing the compile output I simply commented or conditioned them out.

This compiles without warnings on Atmel Studio 7, but as Microchip doesn't update their compiler toolchains very often I'm guessing it's probably still warning free with the latest.

